### PR TITLE
Deleted an extra character in b64_alphabet.

### DIFF
--- a/Base64.cpp
+++ b/Base64.cpp
@@ -2,7 +2,7 @@
 
 const char b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		"abcdefghijklmnopqrstuvwxyz"
-		"01234567890+/";
+		"0123456789+/";
 
 /* 'Private' declarations */
 inline void a3_to_a4(unsigned char * a4, unsigned char * a3);


### PR DESCRIPTION
Hi,

I have written to you about an issue in your b64 code; now I have found it: there was an extra character in the alphabet (a zero), which I have deleted.
Thus, if you want, here is the patch.
