### PR TITLE
Moved the Base64 alphabet into PROGMEM to save RAM

### DIFF
--- a/Base64.cpp
+++ b/Base64.cpp
@@ -1,6 +1,6 @@
 #include "Base64.h"
-
-const char b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#include <avr/pgmspace.h>
+const char PROGMEM b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		"abcdefghijklmnopqrstuvwxyz"
 		"0123456789+/";
 
@@ -21,7 +21,7 @@ int base64_encode(char *output, char *input, int inputLen) {
 			a3_to_a4(a4, a3);
 
 			for(i = 0; i < 4; i++) {
-				output[encLen++] = b64_alphabet[a4[i]];
+				output[encLen++] = pgm_read_byte(&b64_alphabet[a4[i]]);
 			}
 
 			i = 0;
@@ -36,7 +36,7 @@ int base64_encode(char *output, char *input, int inputLen) {
 		a3_to_a4(a4, a3);
 
 		for(j = 0; j < i + 1; j++) {
-			output[encLen++] = b64_alphabet[a4[j]];
+			output[encLen++] = pgm_read_byte(&b64_alphabet[a4[j]]);
 		}
 
 		while((i++ < 3)) {


### PR DESCRIPTION
Storing the whole alphabet in RAM is not needed since it does not change. The string is quite long and thus uses up a lot of valuable RAM.