### PR TITLE
string length bug

### DIFF
--- a/examples/base64/base64.ino
+++ b/examples/base64/base64.ino
@@ -27,7 +27,7 @@ void setup()
   
   // encoding
   char input[] = "Hello world";
-  int inputLen = sizeof(input);
+  int inputLen = sizeof(input)-1;
   
   int encodedLen = base64_enc_len(inputLen);
   char encoded[encodedLen];


### PR DESCRIPTION
line 30:
sizeof() includes the terminating NULL character, which is not intended behaviour.
so either use sizeof()-1,
or use strlen()
