### PR TITLE
Add architecture support

### DIFF
--- a/Base64.cpp
+++ b/Base64.cpp
@@ -1,5 +1,18 @@
 #include "Base64.h"
-#include <avr/pgmspace.h>
+
+#if defined( __AVR__ )
+    #include <avr/pgmspace.h>
+#elif defined( ESP8266 ) // ESP32 should work here too
+    #include <pgmspace.h>
+#elif defined( __arm__ )
+	#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+	#define PROGMEM const
+#else
+    #pragma message("Unknown Architecture. Using compatibility fallback for pgmspace") 
+	#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+	#define PROGMEM const
+#endif
+
 const char PROGMEM b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		"abcdefghijklmnopqrstuvwxyz"
 		"0123456789+/";

--- a/Base64.cpp
+++ b/Base64.cpp
@@ -1,14 +1,14 @@
 #include "Base64.h"
 
 #if defined( __AVR__ )
-    #include <avr/pgmspace.h>
+	#include <avr/pgmspace.h>
 #elif defined( ESP8266 ) // ESP32 should work here too
-    #include <pgmspace.h>
+	#include <pgmspace.h>
 #elif defined( __arm__ )
 	#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 	#define PROGMEM const
 #else
-    #pragma message("Unknown Architecture. Using compatibility fallback for pgmspace") 
+	#pragma message("Unknown Architecture. Using compatibility fallback for pgmspace") 
 	#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 	#define PROGMEM const
 #endif


### PR DESCRIPTION
Fix issue  #11 . Cause is 952f4576379044445bd4a72926245ff34741511e which introduces incompatibility with non-AVR architectures. Works on ESP8266, ARM, etc.
