### PR TITLE
corrected string lengths in example code

### DIFF
--- a/examples/base64/base64.ino
+++ b/examples/base64/base64.ino
@@ -3,11 +3,12 @@
 /*
  Base64 Encode/Decode example
  
- Encodes the text "Hello world" to "SGVsbG8gd29ybGQA" and decodes "Zm9vYmFy" to "foobar"
+ Encodes the text "Hello world" to "SGVsbG8gd29ybGQ=" and decodes "Zm9vYmFy" to "foobar"
 
  Created 29 April 2015
  by Nathan Friedly - http://nfriedly.com/
- 
+ updated by palto42 https://github.com/palto42/
+
  This example code is in the public domain.
 
  */
@@ -27,26 +28,25 @@ void setup()
   
   // encoding
   char input[] = "Hello world";
-  int inputLen = sizeof(input);
+  int inputLen = sizeof(input) - 1; // don't count the trailing \0 of the string
+  // note that the runtime function "strlen()" doesn't count the terminating \0
   
   int encodedLen = base64_enc_len(inputLen);
-  char encoded[encodedLen];
-  
-  Serial.print(input); Serial.print(" = ");
+  char encoded[encodedLen + 1];  // add +1 for \0 string termination
   
   // note input is consumed in this step: it will be empty afterwards
   base64_encode(encoded, input, inputLen); 
   
-  Serial.println(encoded);
+  Serial.print(input); Serial.print(" = "); Serial.println(encoded);
   
   
   
   // decoding
   char input2[] = "Zm9vYmFy";
-  int input2Len = sizeof(input2);
+  int input2Len = sizeof(input2) - 1; // don't count the trailing \0 of the string
   
   int decodedLen = base64_dec_len(input2, input2Len);
-  char decoded[decodedLen];
+  char decoded[decodedLen + 1];  // add +1 for \0 string termination
   
   base64_decode(decoded, input2, input2Len);
   


### PR DESCRIPTION
The encode and decode length must not include the terminating \0 of the string and the length of the output char array must be 1 larger for the \0 added at the end.
The first point caused incorrect encoding and the second caused an overwrite of the first char of the input string.
I validated the encoding of "Hello world" on Ubuntu CLI using `echo -n 'Hello world' | base64`