### PR TITLE
Fix collision with https://github.com/Densaugeo/base64_arduino

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=base64
+name=arduino-base64
 version=1.0.0
 author=Adam Rudd
 maintainer=Adam Rudd


### PR DESCRIPTION
Could you rename your library to arduino-base64 for the Arduino IDE?
Right know it gets confused and wants to update to a different Base64 library [(https://github.com/Densaugeo/base64_arduino)](https://github.com/Densaugeo/base64_arduino) that is available in the updater. 
If a user clicks update your library gets overwritten and the code no longer works.
![2018-06-26 10_32_43-library manager](https://user-images.githubusercontent.com/10356892/41899515-f318ab4a-792c-11e8-8b9d-0af4e77e4c60.png)
